### PR TITLE
Build model artifacts in CI, and save for viewing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -27,4 +27,16 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew clean build
-
+    - name: Install Graphviz
+      run: sudo apt-get install -y graphviz
+    - name: Generate image artifacts
+      run: java -jar ./build/libs/context-mapper-standalone-example-1.0.0-SNAPSHOT.jar -f ./src/main/cml/Insurance-Example-Model.cml -t contextmap
+    - name: Generate PlantUML artifacts
+      run: java -jar ./build/libs/context-mapper-standalone-example-1.0.0-SNAPSHOT.jar -f ./src/main/cml/Insurance-Example-Model.cml -t plantuml
+    - name: Generate MDSL artifacts
+      run: java -jar ./build/libs/context-mapper-standalone-example-1.0.0-SNAPSHOT.jar -f ./src/main/cml/Insurance-Example-Model.cml -t mdsl
+    - name: Save artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: diagrams
+        path: src-gen/


### PR DESCRIPTION
I pulled out the `README.md` changes, and this PR focuses on enhancing the GitHub CI pipeline:

- Run the tool for `contextmap`, `plantuml`, and `mdsn` output formats
- Save the generated files (shows up under Artifacts as the `diagrams.zip` download)
- As a side effect of the `contextmap` output, install the Graphviz package to the build image